### PR TITLE
Fix an error with the link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </h1>
 
 <h3 align="center">
-This is a clone of the Twitter app implemented for the purpose of <a href="https://reactnavigation.org/blog/2020/01/29/using-react-navigation-5-with-react-native-paper.html">this blog post</a> 
+This is a clone of the Twitter app implemented for the purpose of <a href="https://reactnavigation.org/blog/2020/01/29/using-react-navigation-5-with-react-native-paper">this blog post</a> 
 </h3>
 <p align="center">
 <img src="./assets/app.gif" />


### PR DESCRIPTION
The URL finishes with `.html` in the README file although it is not the proper route : https://reactnavigation.org/blog/2020/01/29/using-react-navigation-5-with-react-native-paper